### PR TITLE
add Tiny Helpers to misc category

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,8 @@ Website with a variety of small, helpful tools. Examples include quick URL encod
 - [StackEdit](https://stackedit.io/)
 Browser-based markdown editor.
 
+- [Tiny Helpers](https://tiny-helpers.dev/)
+A collection of free single-purpose online tools for web developers... Examples include tools for CSS, Color, SVG, Accessibility, Performmance, Icons and many more.
+
 - [markdownlint](https://github.com/DavidAnson/markdownlint)
 Visual Studio Code extension for markdown that will lint and style check it. For example, rule MD041 suggests that markdown files start with top-level headings. A list of problems is generated on save, and it offers guidance and automatic fixes. Turn off the rules you disagree with or write your own.


### PR DESCRIPTION
Adds an entry under Miscellaneous for "Tiny Helpers".

## Adding a tooling library
- [x] Suggestion is not a duplicate
- [x] Suggestion is under the proper category (if applicable)
- [x] Link to library is included 
- [x] Name of library is included
- [x] Name and link are spelled correctly
