### PR TITLE
Replace inherit with explicit secret passing

### DIFF
--- a/.github/workflows/pull-request-opened-notify-slack.yml
+++ b/.github/workflows/pull-request-opened-notify-slack.yml
@@ -7,4 +7,5 @@ jobs:
   send-slack-notification:
     if: github.event.pull_request.merged == false
     uses: thisdot/shared-actions/.github/workflows/pull-request-opened-notify-slack.yml@main
-    secrets: inherit
+    secrets:
+      OSS_SLACK_NOTIFICATION_WEBHOOK_URL: ${{ secrets.OSS_SLACK_NOTIFICATION_WEBHOOK_URL }}


### PR DESCRIPTION
Inherit won't work in our use-case. We have to pass OSS_SLACK_NOTIFICATION_WEBHOOK_URL explicitly for the job to use it properly.
